### PR TITLE
Continues to remake images without alt text

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,16 @@ var wrapImageTags = function(page){
         var img = $(this);
 
         // Rebuild the image
-        var $image = $('<img>')
+        if (img.attr("alt") === null) {
+            var $image = $('<img>')
                         .attr('src', img.attr('src'))
                         .attr('alt', img.attr('alt'));
+        //data attribute doesn't exist
+        }else{
+            var $image = $('<img>')
+                        .attr('src', img.attr('src'));
+        //data attribute exists
+        }
 
         // Append the original image
         imageWrapper.append($image);


### PR DESCRIPTION
Some gitbook plugins generate images (plantuml in my case).  Those don't necessarily have alt text, this plugin was removing the images.